### PR TITLE
Added atom feed for news page

### DIFF
--- a/Rules
+++ b/Rules
@@ -83,8 +83,8 @@ route '*' do
   if item.binary?
     # Write item with identifier /foo/ to /foo.ext
     item.identifier.chop + '.' + item[:extension]
-  elsif item[:extension] == 'xml' or item[:extension] == 'rdf'
-    # rss feeds
+  elsif item[:extension] =~ /xml|rdf|atom/
+    # atom, xml or rdf feeds
     item.identifier.chop + '.' + item[:extension]
   else
     # Write item with identifier /foo/ to /foo/index.html

--- a/layouts/default.haml
+++ b/layouts/default.haml
@@ -5,11 +5,15 @@
     %title
       C3TV -
       = @item[:title]
-    %meta{name: 'description', content: ''}
-    %meta{name: 'author', content: ''}
+
+    %meta{name: 'description', content: Settings.header['description']}
+    %meta{name: 'author', content: Settings.header['author']}
+    %meta{name: 'keywords', content: Settings.header['keywords']}
     %meta{'http-equiv' => 'X-UA-Compatible', content: 'IE=edge'}
     %meta{name: 'viewport', content: 'width=device-width, initial-scale=1.0'}
+
     %link{href: '/assets/css/styles.css', rel: 'stylesheet'}
+    %link{href: '/news.atom', rel: 'alternate', title: 'C3TV - News', type: 'application/atom+xml'}
   %body
     = render '/partials/navbar'
 

--- a/lib/data_source/feed_builder.rb
+++ b/lib/data_source/feed_builder.rb
@@ -33,5 +33,13 @@ class FeedBuilder
       channel_summary: "This feed contains events older than two years"
     }
     @item_builder.create_feed_item(xml, 'podcast-archive.xml')
+
+    # news atom feed
+    atom_feed = Feeds::NewsFeedGenerator.generate(News.all, options: {
+        author: Settings.feeds['channel_owner'],
+        about: 'http://media.ccc.de',
+        title: 'CCC TV - NEWS',
+    })
+    @item_builder.create_feed_item(atom_feed, 'news.atom')
   end
 end

--- a/lib/feeds/newsfeed_generator.rb
+++ b/lib/feeds/newsfeed_generator.rb
@@ -1,0 +1,78 @@
+require 'rss/maker'
+
+module Feeds
+  # Atom news feed generator.
+  module NewsFeedGenerator
+
+    # Generate atom feed for given news.
+    #
+    # @example Generate atom feed for given news
+    #   news = News.all
+    #   Feeds::NewsFeedGenerator.generate(news)
+    #     #=> "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<feed xmlns=\"http://www.w3.org/2005/Atom\" …"
+    #
+    # @param news [Array<News>] should be generate to an atom feed
+    # @param options [Hash] to define feed preferences
+    # @option opts [String] :author Feed author
+    # @option opts [String] :about Feed about text
+    # @option opts [String] :title Feed title
+    #
+    # @return [String] atom feed
+    def self.generate(news, options: {})
+      atom_feed = build_feed(news, options)
+      atom_feed.to_s
+    end
+
+    # Build atom feed object for given news.
+    #
+    # @example Generate atom feed object for given news
+    #   news = News.all
+    #   Feeds::NewsFeedGenerator.events(news) #=> #<RSS::Atom::Feed:0x007fbe057c218>
+    #
+    # @param news [Array<News>] to convert to an atom feed
+    # @param options [Hash] to define feed preferences
+    # @option opts [String] :author Feed author
+    # @option opts [String] :about Feed about text
+    # @option opts [String] :title Feed title
+    #
+    # @return [RSS::Atom::Feed] atom feed
+    def self.build_feed(news, options)
+      RSS::Maker.make('atom') do |feed|
+        assign_feed_options(feed, options)
+
+        # Create feed item for every news
+        news.each do |news|
+          feed.items.new_item do |item|
+            assign_item_options(item, news)
+          end
+        end
+      end
+    end
+
+    protected
+
+    # Assign news options to an atom feed item.
+    #
+    # @param item [RSS::Maker::Atom::Feed::Items::Item]
+    # @param news [News] object
+    def self.assign_item_options(item, news)
+      item.updated     = Time.now.to_s
+      item.title       = news.title
+      item.id          = "#{news.id}"
+      item.description = news.body
+      item.published   = news.created_at
+      item.updated     = news.updated_at
+    end
+
+    # Assign options like a title or an author to an atom feed.
+    #
+    # @param feed [RSS::Maker::Atom::Feed] atom feed
+    # @param options [Hash] options
+    def self.assign_feed_options(feed, options)
+      feed.channel.author  = options[:author]
+      feed.channel.updated = Time.now.to_s
+      feed.channel.about   = options[:about]
+      feed.channel.title   = options[:title]
+    end
+  end
+end

--- a/nanoc.yaml.example
+++ b/nanoc.yaml.example
@@ -1,7 +1,7 @@
 # A list of file extensions that nanoc will consider to be textual rather than
 # binary. If an item with an extension not in this list is found,  the file
 # will be considered as binary.
-text_extensions: [ 'coffee', 'css', 'erb', 'haml', 'handlebars', 'hb', 'htm', 'html', 'js', 'less', 'markdown', 'md', 'ms', 'mustache', 'php', 'rb', 'sass', 'scss', 'txt', 'xhtml', 'xml' ]
+text_extensions: [ 'coffee', 'css', 'erb', 'haml', 'handlebars', 'hb', 'htm', 'html', 'js', 'less', 'markdown', 'md', 'ms', 'mustache', 'php', 'rb', 'sass', 'scss', 'txt', 'xhtml', 'xml', 'atom' ]
 
 # The path to the directory where all generated files will be written to. This
 # can be an absolute path starting with a slash, but it can also be path


### PR DESCRIPTION
Created news feed generator class witch fetches all news entries from
database and creates an atom feed (/news.atom) file. The feed is
only included into the news page html header.

Furthermore, missing meta data content for description, author and
keywords in the html header was added.
