### PR TITLE
set new hash without adding an entry into the browser history

### DIFF
--- a/layouts/browse-show-page.haml
+++ b/layouts/browse-show-page.haml
@@ -84,7 +84,7 @@
     %script(src='/assets/js/mediaelement-and-player.min.js')
 
     :javascript
-      var stamp = window.location.hash.split('@')[1];
+      var stamp = window.location.hash.split('&t=')[1];
       $('video').mediaelementplayer({
         usePluginFullScreen: true,
 
@@ -101,7 +101,7 @@
             $.post("http://api.media.ccc.de/public/recordings/count", {event_id: #{@item[:event].id},src: mediaElement.src});
           }, false);
           mediaElement.addEventListener('pause', function() {
-            var hash = '#video@'+Math.round(mediaElement.currentTime);;
+            var hash = '#video&t='+Math.round(mediaElement.currentTime);;
             if(window.history && window.history.replaceState) {
               // set new hash without adding an entry into the browser history
               window.history.replaceState(null, "", hash);
@@ -120,7 +120,7 @@
       
       // activate tab via hash and default to video
       function setTabToHash() {
-        var hash = window.location.hash.split('@')[0]; // split video-stamp of the hash
+        var hash = window.location.hash.split('&')[0]; // split video-stamp of the hash
         var activeTab = $('.nav-tabs a[href=' + hash + '], .nav-tabs a[data-target=' + hash + ']')
           .tab('show');
 


### PR DESCRIPTION
this update solves the back-butten issue when playing & pausing
the code useses the HTML5 History API which is available in nearly all
FF and WebKit's and IE10+. Older browsers get the fallback to
traditional setting window.location.hash, which triggers a new history
event
