### PR TITLE
Add a tab with sharing and embedding features

### DIFF
--- a/content/assets/css/styles.scss
+++ b/content/assets/css/styles.scss
@@ -222,6 +222,30 @@ h1 + .news-item {
       text-decoration: none;
     }
   }
+
+  #embedshare {
+    padding: $padding-large-horizontal;
+    h3 {
+      color: $gray-light;
+      &:first-child {
+        margin-top: 0;
+      }
+    }
+    ul {
+      list-style-type: none;
+      padding: 0;
+      li {
+        min-width: 49%;
+        display: inline-block;
+      }
+      a {
+        margin: 0 $padding-xs-horizontal;
+      }
+    }
+    a:hover, a:focus, a:active {
+      text-decoration: none;
+    }
+  }
 }
 
 ul.metadata {

--- a/layouts/browse-show-page.haml
+++ b/layouts/browse-show-page.haml
@@ -9,6 +9,7 @@
     %link{href: '/assets/css/mediaelementplayer.min.css', type: 'text/css', rel: 'stylesheet'}
     != "<link href='#{oembed_url(@item.identifier)}' rel='alternate' title='media.ccc.de oembed profile' type='application/json+oembed'>"
   %body
+    %script(src='/assets/js/jquery.min.js')
     = render '/partials/navbar'
 
     %div.container-fluid
@@ -33,6 +34,9 @@
         %li
           %a{href: @item[:event].download_url, 'data-target' => '#download', role: 'tab', 'data-toggle' => 'tab'} Download
 
+        %li
+          %a{href: '#embedshare', role: 'tab', 'data-toggle' => 'tab'} Share
+
       .tab-content
         - if @item[:video_recordings].present?
           #video.tab-pane.active
@@ -46,6 +50,9 @@
 
         #download.tab-pane
           = render '/partials/download'
+
+        #embedshare.tab-pane
+          = render '/partials/embedshare'
 
       %ul.metadata
         %li
@@ -76,7 +83,6 @@
 
     = render '/partials/footer'
 
-    %script(src='/assets/js/jquery.min.js')
     %script(src='/assets/js/bootstrap.min.js')
     %script(src='/assets/js/mediaelement-and-player.min.js')
 

--- a/layouts/partials/embedshare.haml
+++ b/layouts/partials/embedshare.haml
@@ -1,0 +1,57 @@
+%h3 Embed into your Website
+%input{:type => "text", :size=> "85", :readonly => true, 
+       :value => "<iframe width=\"853\" height=\"480\" src=\"#{oembed_page_url(@item.identifier)}\" frameborder=\"0\" allowfullscreen></iframe>"}
+%h3 Share with others
+%ul
+  %li
+    %a{:id => "btnTweet", :href => "#"}
+      via Twitter
+  %li
+    %a{:id => "btnFacebook", :href => "#"}
+      via Facebook
+  %li
+    %a{:id => "btnGPlus", :href => "#"}
+      via Google+
+  %li
+    %a{:id => "btnAppNet", :href => "#"}
+      via App.net
+  %li
+    %a{:id => "btnMail", :href => "#"}
+      by Mail
+:javascript
+  $(function () {
+    $('#btnTweet').click(function (e) {
+      var encodedContent = encodeURIComponent("#{@item[:title]}: #{page_url(@item)}");
+      var url = 'http://twitter.com/home?status=' + encodedContent;
+      window.open(url, 'tweet it', 'width=550,height=420,resizable=yes');
+    });
+    $('#btnFacebook').click(function (e) {
+      var encodedTitle = encodeURIComponent("#{@item[:title]}");
+      var encodedLink = encodeURIComponent("#{page_url(@item)}");
+      var url = 'https://www.facebook.com/sharer/sharer.php?t='+encodedTitle+'&u='+encodedLink;
+      window.open(url, 'share it', 'width=550,height=420,resizable=yes');
+      return false;
+    });
+    $('#btnGPlus').click(function (e) {
+      var encodedTitle = encodeURIComponent("#{@item[:title]}");
+      var encodedLink = encodeURIComponent("#{page_url(@item)}");
+      var url = 'https://plus.google.com/share?title='+encodedTitle+'&url='+encodedLink;
+      window.open(url, 'plus it', 'width=550,height=420,resizable=yes');
+      return false;
+    });
+    $('#btnAppNet').click(function (e) {
+      var encodedContent = encodeURIComponent("#{@item[:title]}: #{page_url(@item)}");
+      var url = 'https://alpha.app.net/intent/post?text=' + encodedContent;
+      window.open(url, 'share it', 'width=550,height=420,resizable=yes');
+      return false;
+    });
+    $('#btnMail').click(function (e) {
+      var encodedTitle = encodeURIComponent("#{@item[:title]}");
+      var encodedLink = encodeURIComponent("#{page_url(@item)}");
+      var url = 'mailto:?subject='+encodedTitle+'&body='+encodedTitle+': '+encodedLink;
+      tmpWin = window.open(url);
+      //$(tmpWin.document).ready( function() {tmpWin.close();})
+      return false;
+    });
+  });
+

--- a/layouts/partials/embedshare.haml
+++ b/layouts/partials/embedshare.haml
@@ -21,24 +21,8 @@
       by Mail
 :javascript
   $(function () {
-    $('#btnTweet').click(function (e) {
-      window.open(this.href, 'tweet it', 'width=550,height=420,resizable=yes');
-      e.preventDefault();
-    });
-    $('#btnFacebook').click(function (e) {
+    $('#btnTweet, #btnFacebook, #btnGPlus, #btnAppNet').on('click', function (e) {
       window.open(this.href, 'share it', 'width=550,height=420,resizable=yes');
-      e.preventDefault();
-    });
-    $('#btnGPlus').click(function (e) {
-      window.open(this.href, 'plus it', 'width=550,height=420,resizable=yes');
-      e.preventDefault();
-    });
-    $('#btnAppNet').click(function (e) {
-      window.open(this.href, 'share it', 'width=550,height=420,resizable=yes');
-      e.preventDefault();
-    });
-    $('#btnMail').click(function (e) {
-      tmpWin = window.open(this.href);
       e.preventDefault();
     });
   });

--- a/layouts/partials/embedshare.haml
+++ b/layouts/partials/embedshare.haml
@@ -4,54 +4,42 @@
 %h3 Share with others
 %ul
   %li
-    %a{:id => "btnTweet", :href => "#"}
+    %a{:id => "btnTweet", :href => twitter_url(@item[:title], page_url(@item)) }
       via Twitter
   %li
-    %a{:id => "btnFacebook", :href => "#"}
+    %a{:id => "btnFacebook",
+       :href => facebook_url(@item[:title], page_url(@item)) }
       via Facebook
   %li
-    %a{:id => "btnGPlus", :href => "#"}
+    %a{:id => "btnGPlus", :href => googleplus_url(@item[:title], page_url(@item)) }
       via Google+
   %li
-    %a{:id => "btnAppNet", :href => "#"}
+    %a{:id => "btnAppNet", :href => appnet_url(@item[:title], page_url(@item)) }
       via App.net
   %li
-    %a{:id => "btnMail", :href => "#"}
+    %a{:id => "btnMail", :href => mail_url(@item[:title], page_url(@item)) }
       by Mail
 :javascript
   $(function () {
     $('#btnTweet').click(function (e) {
-      var encodedContent = encodeURIComponent("#{@item[:title]}: #{page_url(@item)}");
-      var url = 'http://twitter.com/home?status=' + encodedContent;
-      window.open(url, 'tweet it', 'width=550,height=420,resizable=yes');
+      window.open(this.href, 'tweet it', 'width=550,height=420,resizable=yes');
+      e.preventDefault();
     });
     $('#btnFacebook').click(function (e) {
-      var encodedTitle = encodeURIComponent("#{@item[:title]}");
-      var encodedLink = encodeURIComponent("#{page_url(@item)}");
-      var url = 'https://www.facebook.com/sharer/sharer.php?t='+encodedTitle+'&u='+encodedLink;
-      window.open(url, 'share it', 'width=550,height=420,resizable=yes');
-      return false;
+      window.open(this.href, 'share it', 'width=550,height=420,resizable=yes');
+      e.preventDefault();
     });
     $('#btnGPlus').click(function (e) {
-      var encodedTitle = encodeURIComponent("#{@item[:title]}");
-      var encodedLink = encodeURIComponent("#{page_url(@item)}");
-      var url = 'https://plus.google.com/share?title='+encodedTitle+'&url='+encodedLink;
-      window.open(url, 'plus it', 'width=550,height=420,resizable=yes');
-      return false;
+      window.open(this.href, 'plus it', 'width=550,height=420,resizable=yes');
+      e.preventDefault();
     });
     $('#btnAppNet').click(function (e) {
-      var encodedContent = encodeURIComponent("#{@item[:title]}: #{page_url(@item)}");
-      var url = 'https://alpha.app.net/intent/post?text=' + encodedContent;
-      window.open(url, 'share it', 'width=550,height=420,resizable=yes');
-      return false;
+      window.open(this.href, 'share it', 'width=550,height=420,resizable=yes');
+      e.preventDefault();
     });
     $('#btnMail').click(function (e) {
-      var encodedTitle = encodeURIComponent("#{@item[:title]}");
-      var encodedLink = encodeURIComponent("#{page_url(@item)}");
-      var url = 'mailto:?subject='+encodedTitle+'&body='+encodedTitle+': '+encodedLink;
-      tmpWin = window.open(url);
-      //$(tmpWin.document).ready( function() {tmpWin.close();})
-      return false;
+      tmpWin = window.open(this.href);
+      e.preventDefault();
     });
   });
 

--- a/lib/helpers/application_helper.rb
+++ b/lib/helpers/application_helper.rb
@@ -1,6 +1,27 @@
 module ApplicationHelper
+  require 'uri'
   require 'nanoc/helpers/html_escape'
   include Nanoc::Helpers::HTMLEscape
+
+  def twitter_url(title, url)
+    "http://twitter.com/home?status="+URI.encode_www_form_component(title+": "+url)
+  end
+
+  def facebook_url(title, url)
+    "https://www.facebook.com/sharer/sharer.php?t="+URI.encode_www_form_component(title)+"&u="+URI.encode_www_form_component(url)
+  end
+
+  def googleplus_url(title, url)
+    "https://plus.google.com/share?title="+URI.encode_www_form_component(title)+"&url="+URI.encode_www_form_component(url)
+  end
+
+  def appnet_url(title, url)
+    "https://alpha.app.net/intent/post?text="+URI.encode_www_form_component(title+": "+url)
+  end
+
+  def mail_url(title, url)
+    "mailto:?subject="+URI.encode_www_form_component(title)+"&body="+URI.encode_www_form_component(title+": "+url)
+  end
 
   def oembed_url(identifier)
     Settings.oembedURL + identifier[0..-2] + '.html'

--- a/lib/helpers/application_helper.rb
+++ b/lib/helpers/application_helper.rb
@@ -20,7 +20,8 @@ module ApplicationHelper
   end
 
   def mail_url(title, url)
-    "mailto:?subject="+URI.encode_www_form_component(title)+"&body="+URI.encode_www_form_component(title+": "+url)
+    content = title+': '+url
+    URI::MailTo.build('', [['Subject', title], ['Body', content]]).to_s
   end
 
   def oembed_url(identifier)

--- a/lib/helpers/application_helper.rb
+++ b/lib/helpers/application_helper.rb
@@ -6,6 +6,16 @@ module ApplicationHelper
     Settings.oembedURL + identifier[0..-2] + '.html'
   end
 
+  def oembed_page_url(identifier)
+    id = identifier+"oembed/"
+    oembed = @items.find { |i| i.identifier == id }
+    Settings.baseURL + oembed.path
+  end
+
+  def page_url(identifier)
+    Settings.baseURL + identifier.path
+  end
+
   def event_page_or_folder(item)
     return if @item.identifier.include? '/tags/'
     trail = breadcrumbs_trail

--- a/settings.json
+++ b/settings.json
@@ -1,4 +1,5 @@
 {
+  "baseURL": "http://media.ccc.de",
   "oembedURL": "http://api.media.ccc.de/public/oembed?url=http://media.ccc.de",
   "cdnURL": "http://cdn.media.ccc.de",
   "staticURL": "http://static.media.ccc.de",


### PR DESCRIPTION
This adds a tab with sharing links on social networks (privacy compliant as in: you have to click the link before a site can track what you do), plus embedding sourcecode (width/height needs testing).